### PR TITLE
Removing the master-slave vocabulary

### DIFF
--- a/Piper/Alexandra/python-dateutil-1.5/dateutil/parser.py
+++ b/Piper/Alexandra/python-dateutil-1.5/dateutil/parser.py
@@ -31,7 +31,7 @@ __all__ = ["parse", "parserinfo"]
 # http://www.cl.cam.ac.uk/~mgk25/iso-time.html
 # http://www.iso.ch/iso/en/prods-services/popstds/datesandtime.html
 # http://www.w3.org/TR/NOTE-datetime
-# http://ringmaster.arc.nasa.gov/tools/time_formats.html
+# http://ringmain.arc.nasa.gov/tools/time_formats.html
 # http://search.cpan.org/author/MUIR/Time-modules-2003.0211/lib/Time/ParseDate.pm
 # http://stein.cshl.org/jade/distrib/docs/java.text.SimpleDateFormat.html
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.